### PR TITLE
(+semver: feature) Current year in copyright notice

### DIFF
--- a/content/.template.config/template.json
+++ b/content/.template.config/template.json
@@ -37,6 +37,14 @@
             "defaultValue": "open-source@gmvsync.com",
             "replaces": "$contactEmail"
         },
+        "copyrightYear": {
+            "type": "generated",
+            "generator": "now",
+            "replaces": "$copyrightYear",
+            "parameters": {
+                "format": "yyyy"
+            }
+        },
         "githubOwner": {
             "type": "parameter",
             "defaultValue": "syncromatics",

--- a/content/LICENSE
+++ b/content/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 $authorName
+Copyright (c) $copyrightYear $authorName
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
When generating the LICENSE file, use the current year instead of hard-coding 2017.